### PR TITLE
CAMLlocal bug in stubs

### DIFF
--- a/src/alsa_stubs.c
+++ b/src/alsa_stubs.c
@@ -228,7 +228,6 @@ static struct custom_operations hw_params_ops =
 
 static value create_hw_params()
 {
-  CAMLlocal1(ans);
   snd_pcm_hw_params_t *params;
 
   check_for_err(snd_pcm_hw_params_malloc(&params));


### PR DESCRIPTION
You cannot use the `CAMLlocal*` macros without an enclosing `CAMLparam*`, otherwise you end up accessing a piece of the stack that was deallocated (and potentially reused). OCaml 4.04.0 guards against this mistake.

Since there is no allocation between the initialization of `ans` and the `return`, you don't need the call to `CAMLlocal1`.
